### PR TITLE
1번 테스트케이스로 컴파일 에러 여부 확인

### DIFF
--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -190,7 +190,13 @@ const SolveView: React.FC<SolveViewProps> = ({
                     const newTestCases = [...currentTestCases];
                     newTestCases[0].result = output;
                     setTargetTestCases(newTestCases);
-                    if (checkCompileError(lang, output)) {
+                    if (output === 'error') {
+                        setTestCaseState('error');
+                        setErrorMessage(
+                            `컴파일 서버에서 오류가 발생했습니다.\n`
+                        );
+                        resolve(true);
+                    } else if (checkCompileError(lang, output)) {
                         setTestCaseState('error');
                         setErrorMessage(output);
                         resolve(true);

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -133,42 +133,73 @@ const SolveView: React.FC<SolveViewProps> = ({
         const currentTestCases = [...testCases, ...customTestCases];
         setTargetTestCases(currentTestCases);
 
+        if (currentTestCases.length === 0) return;
+
         currentTestCases.forEach((testCase) => {
             testCase.result = undefined;
         });
 
+        const firstCaseError = await checkFirstCase(currentTestCases);
+        if (firstCaseError) return;
+
         Promise.all(
-            currentTestCases.map(async (testCase, index) => {
-                const data: CodeCompileRequest = {
+            currentTestCases.slice(1).map((testCase, index) => {
+                const data = {
                     lang: lang,
                     code: code,
                     input: testCase.input,
                 };
 
-                chrome.runtime.sendMessage(
-                    { action: 'compile', data: data },
-                    (output) => {
-                        const newTestCases = [...currentTestCases];
-                        newTestCases[index].result = output;
-                        setTargetTestCases(newTestCases);
-                        if (checkCompileError(lang, output)) {
-                            setTestCaseState('error');
-                            setErrorMessage(output);
-                            return;
+                return new Promise((resolve, reject) => {
+                    chrome.runtime.sendMessage(
+                        { action: 'compile', data: data },
+                        (output) => {
+                            const newTestCases = [...currentTestCases];
+                            newTestCases[index + 1].result = output;
+                            setTargetTestCases(newTestCases);
+                            if (output === 'error') {
+                                setTestCaseState('error');
+                                setErrorMessage(
+                                    `컴파일 서버에서 오류가 발생했습니다.\n`
+                                );
+                                reject(output);
+                            } else {
+                                resolve(output);
+                            }
                         }
-                        if (output == 'error') {
-                            setTestCaseState('error');
-                            setErrorMessage(
-                                `컴파일 서버에서 오류가 발생했습니다.\n`
-                            );
-                            return;
-                        }
-                    }
-                );
+                    );
+                });
             })
         );
 
         setTestCaseState('result');
+    };
+
+    const checkFirstCase = (currentTestCases: TestCase[]) => {
+        const lang = convertLanguageIdForSubmitApi(languageId);
+        const data = {
+            lang: lang,
+            code: code,
+            input: currentTestCases[0].input,
+        };
+
+        return new Promise((resolve) => {
+            chrome.runtime.sendMessage(
+                { action: 'compile', data: data },
+                (output) => {
+                    const newTestCases = [...currentTestCases];
+                    newTestCases[0].result = output;
+                    setTargetTestCases(newTestCases);
+                    if (checkCompileError(lang, output)) {
+                        setTestCaseState('error');
+                        setErrorMessage(output);
+                        resolve(true);
+                    } else {
+                        resolve(false);
+                    }
+                }
+            );
+        });
     };
 
     const codeSubmit = () => {

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -142,7 +142,7 @@ const SolveView: React.FC<SolveViewProps> = ({
         const firstCaseError = await checkFirstCase(currentTestCases);
         if (firstCaseError) return;
 
-        Promise.all(
+        await Promise.all(
             currentTestCases.slice(1).map((testCase, index) => {
                 const data = {
                     lang: lang,


### PR DESCRIPTION
## ✅ DONE

- 1번 테스트케이스 먼저 실행 후 컴파일 에러이면 다른 테스트케이스 실행하지 않기
- 모든 테스트케이스가 실행되기 전에 실행버튼이 다시 활성화되는 문제 해결
  (모든 테스트케이스가 실행될 때까지는 실행 버튼이 비활성화됩니다.)

## 🚀 RESULT
테스트케이스가 3개 있는 문제로 테스트하였습니다!
- 기존 : 컴파일 에러 시에도 3개의 테스트케이스가 모두 돌아갑니다.
![image](https://github.com/algo-plus/algo-plus/assets/72266806/9c9c13f1-55c0-49ab-b9c6-ffb9045396e5)
- 변경 후 : 테스트케이스를 세 번 실행한 사진입니다. 컴파일 에러 시에는 한 번만 돌아가는 것을 확인할 수 있습니다. 
![image](https://github.com/algo-plus/algo-plus/assets/72266806/f8b0e602-d726-485d-81e1-310222f81997)

테스트케이스가 실행 중일 때 버튼
![image](https://github.com/algo-plus/algo-plus/assets/72266806/41b6ee78-74eb-45e0-8879-518fcd274e8b)
