### PR TITLE
코드 에디터 언어 기본값 설정 기능 구현

### DIFF
--- a/src/baekjoon/components/LanguageSelectBox/LanguageSelectBox.tsx
+++ b/src/baekjoon/components/LanguageSelectBox/LanguageSelectBox.tsx
@@ -4,12 +4,14 @@ interface LanguageSelectBoxProps {
     value: string;
     onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
     onFocus: () => void;
+    onChangeDefaultLanguage: () => void;
 }
 
 const LanguageSelectBox: React.FC<LanguageSelectBoxProps> = ({
     value,
     onChange,
     onFocus,
+    onChangeDefaultLanguage,
 }) => {
     return (
         <div
@@ -20,6 +22,7 @@ const LanguageSelectBox: React.FC<LanguageSelectBoxProps> = ({
                 marginRight: '10px',
             }}
         >
+            <a onClick={onChangeDefaultLanguage}>현재 언어를 기본값으로 설정</a>
             <label className='control-label'>언어</label>
             <div>
                 <select

--- a/src/baekjoon/components/LanguageSelectBox/LanguageSelectBox.tsx
+++ b/src/baekjoon/components/LanguageSelectBox/LanguageSelectBox.tsx
@@ -22,7 +22,9 @@ const LanguageSelectBox: React.FC<LanguageSelectBoxProps> = ({
                 marginRight: '10px',
             }}
         >
-            <a onClick={onChangeDefaultLanguage}>현재 언어를 기본값으로 설정</a>
+            <a onClick={onChangeDefaultLanguage} style={{ cursor: 'pointer' }}>
+                현재 언어를 기본값으로 설정
+            </a>
             <label className='control-label'>언어</label>
             <div>
                 <select

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -290,10 +290,13 @@ const SolveView: React.FC<SolveViewProps> = ({
 
     useEffect(() => {
         loadEditorCode(problemId).then((value: EditorCode) => {
-            const languageDefaultCode = getDefaultCode(
-                convertLanguageIdForEditor(value.languageId as string)
-            );
-            if (value && value.code != languageDefaultCode) {
+            if (
+                value &&
+                value.code !=
+                    getDefaultCode(
+                        convertLanguageIdForEditor(value.languageId as string)
+                    )
+            ) {
                 setLanguageId(value.languageId as string);
                 setCode(value.code);
             } else {

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -221,6 +221,13 @@ const SolveView: React.FC<SolveViewProps> = ({
         );
     };
 
+    const changeLanguage = (languageId: string) => {
+        const editorLanguage = convertLanguageIdForEditor(languageId);
+        setLanguageId(languageId);
+        setCode(getDefaultCode(editorLanguage));
+        saveEditorCode(problemId, languageId, code);
+    };
+
     useEffect(() => {
         const loadProblemData = async () => {
             const loadedProblemContent = await loadAndParseProblemDetail(
@@ -281,16 +288,12 @@ const SolveView: React.FC<SolveViewProps> = ({
         setEditorLanguage(editorLanguage);
     }, [languageId]);
 
-    const changeLanguage = (languageId: string) => {
-        const editorLanguage = convertLanguageIdForEditor(languageId);
-        setLanguageId(languageId);
-        setCode(getDefaultCode(editorLanguage));
-        saveEditorCode(problemId, languageId, code);
-    };
-
     useEffect(() => {
         loadEditorCode(problemId).then((value: EditorCode) => {
-            if (value) {
+            const languageDefaultCode = getDefaultCode(
+                convertLanguageIdForEditor(value.languageId as string)
+            );
+            if (value && value.code != languageDefaultCode) {
                 setLanguageId(value.languageId as string);
                 setCode(value.code);
             } else {

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -125,7 +125,7 @@ const SolveView: React.FC<SolveViewProps> = ({
 
     const saveEditorDefaultLanguage = () => {
         saveDefaultLanguageId(languageId);
-        alert('현재 언어를 기본값으로 설정했습니다."');
+        alert('현재 언어를 기본값으로 설정했습니다.');
     };
 
     const codeRun = async () => {

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -37,6 +37,8 @@ import {
     loadTestCases,
     saveEditorCode,
     saveTestCases,
+    loadDefaultLanguageId,
+    saveDefaultLanguageId,
 } from '@/baekjoon/utils/storage/editor';
 import { checkCompileError } from '@/baekjoon/utils/compile';
 
@@ -120,6 +122,11 @@ const SolveView: React.FC<SolveViewProps> = ({
     useEffect(() => {
         setTargetTestCases([...testCases]);
     }, [testCases]);
+
+    const saveEditorDefaultLanguage = () => {
+        saveDefaultLanguageId(languageId);
+        alert('현재 언어를 기본값으로 설정했습니다."');
+    };
 
     const codeRun = async () => {
         if (!code) {
@@ -261,11 +268,7 @@ const SolveView: React.FC<SolveViewProps> = ({
                 '언어 변경 시 작성 중인 코드가 지워집니다.\n변경하시겠습니까?'
             )
         ) {
-            const selectedLanguage = event.target.value;
-            const editorLanguage = convertLanguageIdForEditor(selectedLanguage);
-            setLanguageId(selectedLanguage);
-            setCode(getDefaultCode(editorLanguage));
-            saveEditorCode(problemId, languageId, code);
+            changeLanguage(event.target.value);
         } else {
             setLanguageId(focusLanguageId);
             const editorLanguage = convertLanguageIdForEditor(focusLanguageId);
@@ -278,11 +281,22 @@ const SolveView: React.FC<SolveViewProps> = ({
         setEditorLanguage(editorLanguage);
     }, [languageId]);
 
+    const changeLanguage = (languageId: string) => {
+        const editorLanguage = convertLanguageIdForEditor(languageId);
+        setLanguageId(languageId);
+        setCode(getDefaultCode(editorLanguage));
+        saveEditorCode(problemId, languageId, code);
+    };
+
     useEffect(() => {
         loadEditorCode(problemId).then((value: EditorCode) => {
             if (value) {
                 setLanguageId(value.languageId as string);
                 setCode(value.code);
+            } else {
+                loadDefaultLanguageId().then((languageId: string) => {
+                    changeLanguage(languageId);
+                });
             }
         });
         loadTestCases(problemId).then((value: TestCase[]) => {
@@ -358,6 +372,9 @@ const SolveView: React.FC<SolveViewProps> = ({
                                     value={languageId}
                                     onChange={languageChangeHandle}
                                     onFocus={languageFocusHandle}
+                                    onChangeDefaultLanguage={
+                                        saveEditorDefaultLanguage
+                                    }
                                 />
                             </div>
                             <VerticalSplitView

--- a/src/baekjoon/utils/storage/editor.ts
+++ b/src/baekjoon/utils/storage/editor.ts
@@ -6,6 +6,7 @@ import {
 
 const EDITOR_CODE_STORAGE_PREFIX = 'algoplus-editor-save-';
 const EDITOR_THEME_STORAGE_KEY = 'algoplus-editor-theme-';
+const EDITOR_DEFAULT_LANGUAGE_KEY = 'algoplus-default-language-';
 const TEST_CASE_STORAGE_PREFIX = 'algoplus-test-case-';
 
 const saveEditorCode = async (
@@ -56,6 +57,17 @@ const loadTheme = async (): Promise<string> => {
     return result ? result : 'vs-code-dark';
 };
 
+const saveDefaultLanguageId = async (languageId: string) => {
+    await saveObjectInLocalStorage({
+        [EDITOR_DEFAULT_LANGUAGE_KEY]: languageId,
+    });
+};
+
+const loadDefaultLanguageId = async (): Promise<string> => {
+    const result = await getObjectFromLocalStorage(EDITOR_DEFAULT_LANGUAGE_KEY);
+    return result ? result : 'c';
+};
+
 export {
     saveEditorCode,
     loadEditorCode,
@@ -63,4 +75,6 @@ export {
     loadTestCases,
     saveTheme,
     loadTheme,
+    saveDefaultLanguageId,
+    loadDefaultLanguageId,
 };

--- a/src/baekjoon/utils/storage/editor.ts
+++ b/src/baekjoon/utils/storage/editor.ts
@@ -65,7 +65,7 @@ const saveDefaultLanguageId = async (languageId: string) => {
 
 const loadDefaultLanguageId = async (): Promise<string> => {
     const result = await getObjectFromLocalStorage(EDITOR_DEFAULT_LANGUAGE_KEY);
-    return result ? result : 'c';
+    return result ? result : '0';
 };
 
 export {


### PR DESCRIPTION
## ✅ DONE

- 문제풀이 화면에 에디터 코드 기본 값 설정 버튼, 기능 구현
- 스토리지에 기본 언어 저장 후 불러오기 

## 📝 TODO

- 옵션창에서 언어 설정 가능

## 🚀 RESULT

![image](https://github.com/algo-plus/algo-plus/assets/80024307/9ae64535-4374-41e9-b480-c5463a3bb52a)
![image](https://github.com/algo-plus/algo-plus/assets/80024307/53421298-646e-4d91-8507-f08a2fe607ba)

