### PR TITLE
C11, C++17 버전 추가

### DIFF
--- a/src/baekjoon/components/LanguageSelectBox/LanguageSelectBox.tsx
+++ b/src/baekjoon/components/LanguageSelectBox/LanguageSelectBox.tsx
@@ -40,8 +40,14 @@ const LanguageSelectBox: React.FC<LanguageSelectBoxProps> = ({
                         cursor: 'pointer',
                     }}
                 >
+                    <option value='75' data-mime='text/x-csrc'>
+                        C11
+                    </option>
                     <option value='0' data-mime='text/x-csrc'>
                         C99
+                    </option>
+                    <option value='84' data-mime='text/x-c++src'>
+                        C++17
                     </option>
                     <option value='95' data-mime='text/x-c++src'>
                         C++20

--- a/src/baekjoon/utils/language.ts
+++ b/src/baekjoon/utils/language.ts
@@ -3,6 +3,8 @@ import { EditorLanguage, ReferenceLanguage } from '@/common/types/language';
 
 const submitApiLanguageConvertMap: Record<string, CompilerLanguage> = {
     '0': 'c',
+    '75': 'c',
+    '84': 'c_cpp',
     '95': 'c_cpp',
     '86': 'csharp',
     '3': 'java',
@@ -18,6 +20,8 @@ const submitApiLanguageConvertMap: Record<string, CompilerLanguage> = {
 
 const editorLanguageConvertMap: Record<string, EditorLanguage> = {
     '0': 'c',
+    '75': 'c',
+    '84': 'cpp',
     '95': 'cpp',
     '86': 'csharp',
     '3': 'java',
@@ -32,8 +36,10 @@ const editorLanguageConvertMap: Record<string, EditorLanguage> = {
 };
 
 const ReferenceLanguageConvertMap: Record<string, ReferenceLanguage> = {
-    '0': 'c',
-    '95': 'cpp',
+    '0': 'c99',
+    '75': 'c11',
+    '84': 'cpp17',
+    '95': 'cpp20',
     '86': 'csharp',
     '3': 'java8',
     '93': 'java11',

--- a/src/common/types/language.ts
+++ b/src/common/types/language.ts
@@ -11,8 +11,10 @@ type EditorLanguage =
     | 'go';
 
 type ReferenceLanguage =
-    | 'c'
-    | 'cpp'
+    | 'c11'
+    | 'c99'
+    | 'cpp17'
+    | 'cpp20'
     | 'csharp'
     | 'java8'
     | 'java11'

--- a/src/common/utils/language-reference-url.ts
+++ b/src/common/utils/language-reference-url.ts
@@ -1,8 +1,10 @@
 import { ReferenceLanguage } from '@/common/types/language';
 
 const referenceUrl: Record<ReferenceLanguage, string> = {
-    c: 'https://en.cppreference.com/w/c',
-    cpp: 'https://en.cppreference.com/w/cpp',
+    c11: 'https://en.cppreference.com/w/c',
+    c99: 'https://en.cppreference.com/w/c',
+    cpp17: 'https://en.cppreference.com/w/cpp',
+    cpp20: 'https://en.cppreference.com/w/cpp',
     csharp: 'https://learn.microsoft.com/en-us/dotnet/api/?view=netframework-4.6.2&preserve-view=true',
     java8: 'https://docs.oracle.com/javase/8/docs/api/index.html',
     java11: 'https://docs.oracle.com/javase/11/docs/api/index.html',

--- a/src/common/utils/language-reference-url.ts
+++ b/src/common/utils/language-reference-url.ts
@@ -1,10 +1,10 @@
 import { ReferenceLanguage } from '@/common/types/language';
 
 const referenceUrl: Record<ReferenceLanguage, string> = {
-    c11: 'https://en.cppreference.com/w/c',
-    c99: 'https://en.cppreference.com/w/c',
-    cpp17: 'https://en.cppreference.com/w/cpp',
-    cpp20: 'https://en.cppreference.com/w/cpp',
+    c11: 'https://en.cppreference.com/w/c/11',
+    c99: 'https://en.cppreference.com/w/c/99',
+    cpp17: 'https://en.cppreference.com/w/cpp/17',
+    cpp20: 'https://en.cppreference.com/w/cpp/20',
     csharp: 'https://learn.microsoft.com/en-us/dotnet/api/?view=netframework-4.6.2&preserve-view=true',
     java8: 'https://docs.oracle.com/javase/8/docs/api/index.html',
     java11: 'https://docs.oracle.com/javase/11/docs/api/index.html',


### PR DESCRIPTION
## ✅ DONE

- C11, C++17 버전 추가
- C언어, C++ 버전별 공식 문서 링크 사용
```
c11: https://en.cppreference.com/w/c/11
c99: https://en.cppreference.com/w/c/99
cpp17: https://en.cppreference.com/w/cpp/17
cpp20: https://en.cppreference.com/w/cpp/20
```


## 🚀 RESULT

![image](https://github.com/user-attachments/assets/e80e5845-450f-4ca1-ab6c-6a656d61b512)
![image](https://github.com/user-attachments/assets/32773980-bc5c-4796-93ba-ecca87ba2e0b)

