### PR TITLE
Release 브랜치 JDoodle Compile API 변경 사항 적용

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,4 @@
+import { postprecessOutput } from './baekjoon/utils/compile';
 import { CodeCompileRequest } from './common/types/compile';
 
 /**
@@ -23,7 +24,8 @@ async function compile(data: CodeCompileRequest) {
         }
     )
         .then((response) => response.json())
-        .then((json) => json.output.trim());
+        .then((json) => json.output.trim())
+        .then((output) => postprecessOutput(data.language, output));
 }
 
 function handleMessage(request: any, sender: any, sendResponse: any) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -16,7 +16,7 @@ async function SolvedApiCall(problemId: number) {
  */
 async function compile(data: CodeCompileRequest) {
     return fetch(
-        'https://snctz97usk.execute-api.ap-northeast-2.amazonaws.com/api/jdoodle',
+        'https://xk4e9t1zac.execute-api.ap-northeast-2.amazonaws.com/execution/JdoodleCaller',
         {
             method: 'POST',
             body: JSON.stringify(data),

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -42,7 +42,10 @@ import {
     loadDefaultLanguageId,
     saveDefaultLanguageId,
 } from '@/baekjoon/utils/storage/editor';
-import { checkCompileError } from '@/baekjoon/utils/compile';
+import {
+    checkCompileError,
+    preprocessSourceCode,
+} from '@/baekjoon/utils/compile';
 import { getReferenceUrl } from '@/common/utils/language-reference-url';
 
 type SolveViewProps = {
@@ -147,6 +150,7 @@ const SolveView: React.FC<SolveViewProps> = ({
 
         const language = convertLanguageIdForSubmitApi(languageId);
         const versionIndex = convertLanguageVersionForSubmitApi(languageId);
+        const script = preprocessSourceCode(language, code);
         const currentTestCases = [...testCases, ...customTestCases];
         setTargetTestCases(currentTestCases);
 
@@ -159,7 +163,7 @@ const SolveView: React.FC<SolveViewProps> = ({
                 const data: CodeCompileRequest = {
                     language: language,
                     versionIndex: versionIndex,
-                    script: code,
+                    script: script,
                     stdin: testCase.input,
                 };
 

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -19,6 +19,7 @@ import {
     convertLanguageIdForEditor,
     convertLanguageIdForReference,
     convertLanguageIdForSubmitApi,
+    convertLanguageVersionForSubmitApi,
 } from '@/baekjoon/utils/language';
 import { CodeCompileRequest } from '@/common/types/compile';
 import { CodeOpenSelector } from '@/baekjoon/components/CodeOpenSelector';
@@ -144,7 +145,8 @@ const SolveView: React.FC<SolveViewProps> = ({
         saveEditorCode(problemId, languageId, code);
         setTestCaseState('running');
 
-        const lang = convertLanguageIdForSubmitApi(languageId);
+        const language = convertLanguageIdForSubmitApi(languageId);
+        const versionIndex = convertLanguageVersionForSubmitApi(languageId);
         const currentTestCases = [...testCases, ...customTestCases];
         setTargetTestCases(currentTestCases);
 
@@ -155,9 +157,10 @@ const SolveView: React.FC<SolveViewProps> = ({
         Promise.all(
             currentTestCases.map(async (testCase, index) => {
                 const data: CodeCompileRequest = {
-                    lang: lang,
-                    code: code,
-                    input: testCase.input,
+                    language: language,
+                    versionIndex: versionIndex,
+                    script: code,
+                    stdin: testCase.input,
                 };
 
                 chrome.runtime.sendMessage(
@@ -166,7 +169,7 @@ const SolveView: React.FC<SolveViewProps> = ({
                         const newTestCases = [...currentTestCases];
                         newTestCases[index].result = output;
                         setTargetTestCases(newTestCases);
-                        if (checkCompileError(lang, output)) {
+                        if (checkCompileError(language, output)) {
                             setTestCaseState('error');
                             setErrorMessage(output);
                             return;

--- a/src/baekjoon/utils/compile.ts
+++ b/src/baekjoon/utils/compile.ts
@@ -25,8 +25,32 @@ const preprocessSourceCode = (
     return code;
 };
 
+/* JDoodle compile API 동작 후 처리가 필요한 경우 출력 결과를 후처리 */
+const postprecessOutput = (
+    language: CompilerLanguage,
+    output: string
+): string => {
+    if (output.includes('JDoodle.kt') && !output.startsWith('\nJDoodle.kt')) {
+        output = output.split('JDoodle.kt')[0];
+    }
+    if (language === 'csharp' && output.includes('0 Error(s)')) {
+        const parts = output.split('Time Elapsed')[1].split('\n', 1);
+        output = parts.length > 1 ? parts[1] : parts[0];
+    }
+    if (output.includes('JDoodle - output Limit reached.')) {
+        output = '출력 초과';
+    }
+    if (
+        output.includes('JDOODLE_TIMEOUT_LIMIT_EXCEEDED') ||
+        output.includes('JDoodle - Timeout')
+    ) {
+        output = '시간 초과';
+    }
+    return output;
+};
+
 const checkCompileError = (lang: CompilerLanguage, output: string): boolean => {
     return output.includes(CompileErrorFormatConvertMap[lang]);
 };
 
-export { preprocessSourceCode, checkCompileError };
+export { preprocessSourceCode, postprecessOutput, checkCompileError };

--- a/src/baekjoon/utils/compile.ts
+++ b/src/baekjoon/utils/compile.ts
@@ -14,8 +14,19 @@ const CompileErrorFormatConvertMap: Record<CompilerLanguage, string> = {
     go: 'jdoodle.go',
 };
 
+/* JDoodle compile API 동작을 위한 별도의 처리가 필요한 경우 코드를 전처리 */
+const preprocessSourceCode = (
+    language: CompilerLanguage,
+    code: string
+): string => {
+    if (language == 'kotlin') {
+        code = '@file:JvmName("JDoodle")\n' + code;
+    }
+    return code;
+};
+
 const checkCompileError = (lang: CompilerLanguage, output: string): boolean => {
     return output.includes(CompileErrorFormatConvertMap[lang]);
 };
 
-export { checkCompileError };
+export { preprocessSourceCode, checkCompileError };

--- a/src/baekjoon/utils/compile.ts
+++ b/src/baekjoon/utils/compile.ts
@@ -2,6 +2,7 @@ import { CompilerLanguage } from '@/common/types/compile';
 
 const CompileErrorFormatConvertMap: Record<CompilerLanguage, string> = {
     c: 'main.c',
+    cpp17: 'jdoodle.cpp',
     cpp: 'jdoodle.cpp',
     csharp: '/home/Program.cs',
     java: 'Main.java',

--- a/src/baekjoon/utils/language.ts
+++ b/src/baekjoon/utils/language.ts
@@ -4,8 +4,8 @@ import { EditorLanguage, ReferenceLanguage } from '@/common/types/language';
 const submitApiLanguageConvertMap: Record<string, CompilerLanguage> = {
     '0': 'c',
     '75': 'c',
-    '84': 'cpp',
-    '95': 'cpp',
+    '84': 'cpp17',
+    '95': 'cpp17',
     '86': 'csharp',
     '3': 'java',
     '93': 'java',
@@ -16,6 +16,23 @@ const submitApiLanguageConvertMap: Record<string, CompilerLanguage> = {
     '68': 'ruby',
     '74': 'swift',
     '12': 'go',
+};
+
+const submitApiVersionConvertMap: Record<string, string> = {
+    '0': '5',
+    '75': '5',
+    '84': '1',
+    '95': '1',
+    '86': '3',
+    '3': '0',
+    '93': '3',
+    '28': '5',
+    '73': '5',
+    '17': '4',
+    '69': '4',
+    '68': '5',
+    '74': '5',
+    '12': '5',
 };
 
 const editorLanguageConvertMap: Record<string, EditorLanguage> = {
@@ -56,6 +73,12 @@ export const convertLanguageIdForSubmitApi = (
     languageId: string
 ): CompilerLanguage => {
     return submitApiLanguageConvertMap[languageId];
+};
+
+export const convertLanguageVersionForSubmitApi = (
+    languageId: string
+): string => {
+    return submitApiVersionConvertMap[languageId];
 };
 
 export const convertLanguageIdForEditor = (

--- a/src/common/types/compile.ts
+++ b/src/common/types/compile.ts
@@ -1,11 +1,14 @@
 type CodeCompileRequest = {
-    lang: CompilerLanguage;
-    code: string;
-    input?: string | null;
+    language: CompilerLanguage;
+    script: string;
+    versionIndex: string;
+    stdin?: string | null;
+    compileOnly?: boolean;
 };
 
 type CompilerLanguage =
     | 'c'
+    | 'cpp17'
     | 'cpp'
     | 'csharp'
     | 'java'


### PR DESCRIPTION
## ✅ DONE

- 기존 Rapid에 맞춰진 컴파일 API 호출 양식 JDoodle API에 맞게 수정
    - 기존 속성명 변경
    - versionIndex, compileOnly 속성 추가
- 작업을 위해 Jdoodle 수정용 AWS Lamdba 게이트웨이 사용
    - https://xk4e9t1zac.execute-api.ap-northeast-2.amazonaws.com/execution/JdoodleCaller
- AWS Lambda에서 처리하던 로직 옮김
    - 소스 코드 전처리 작업, 실행 결과 후처리 작업 등

## 📝 TODO

- JDoodle을 위한 변경 사항 Main 브랜치에 적용
    - Release 브랜치에 우선 적용 후 Main 브랜치에 적용할 예정
- AWS Lambda 소스 코드 변경
- 시간 초과, 출력 초과, 메모리 초과 경우 출력 화면 개선

## 🚀 RESULT

![image](https://github.com/user-attachments/assets/adfbbf62-6c5e-48e4-a63e-f4d6be870290)
