### PR TITLE
다크 테마 에디터에만 적용 및 BOJ Extended 스타일 충돌 해결

### DIFF
--- a/src/baekjoon/scripts/submit.css
+++ b/src/baekjoon/scripts/submit.css
@@ -8,10 +8,6 @@
     display: none;
 }
 
-::-webkit-scrollbar {
-    width: 10px !important;
-}
-
 .btn-primary {
     color: #fff !important;
     background-color: #428bca !important;
@@ -23,217 +19,102 @@
 }
 
 /* 다크 모드를 위한 스타일 설정 */
-.algoplus-dark-theme #solve-view {
-    background-color: #222222;
-    color: white;
-}
-
-.algoplus-dark-theme .headline > h2,
-.algoplus-dark-theme .panel.left * {
-    color: white;
-}
-
-.algoplus-dark-theme .headline {
-    border-bottom-color: #4a4a4a !important;
-}
-
-.algoplus-dark-theme .headline > h2 {
-    color: #fff;
-    border-bottom-color: #b5b5b5 !important;
-}
-
-.algoplus-dark-theme blockquote {
-    border-left-color: #4a4a4a !important;
-}
-
-.algoplus-dark-theme .page-header,
-.algoplus-dark-theme #problem-info th {
-    border-bottom-color: #4a4a4a !important;
-}
-
-.algoplus-dark-theme #problem-info td {
-    border-top-color: #2d2d2d !important;
-}
-
-.algoplus-dark-theme pre,
-.algoplus-dark-theme .test-case-element > textarea[disabled] {
-    background-color: rgba(128, 128, 128, 0.05) !important;
-    border-color: #3c3c3c !important;
-    color: white !important;
-}
-
-.algoplus-dark-theme .test-case-element > textarea {
-    background-color: #5f5f5f !important;
-    color: white !important;
-}
-
-.algoplus-dark-theme .resizer {
-    background-color: #7f7f7f;
-}
-
-.algoplus-dark-theme .resizer:active,
-.algoplus-dark-theme .resizer:hover {
-    background-color: #4d92cb;
-}
-
-.algoplus-dark-theme ::-webkit-scrollbar-track {
-    background-color: transparent !important;
-}
-
-.algoplus-dark-theme .panel.right a {
-    color: #89c4e8 !important;
-}
-
-.algoplus-dark-theme select {
-    background-color: #3f3f3f;
-    border: 1px solid #eee;
-}
-
-.algoplus-dark-theme .panel.bottom {
+html[theme='dark'] .panel.bottom {
     background-color: #2f2f2f !important;
     border-color: #3f3f3f !important;
 }
 
-.algoplus-dark-theme .panel.bottom h4,
-.algoplus-dark-theme .panel.bottom p {
+html[theme='dark'] .panel.bottom h4,
+html[theme='dark'] .panel.bottom p {
     color: white !important;
 }
 
-.algoplus-dark-theme .btn-default {
+html[theme='dark'] .loading-dot {
+    background-color: white !important;
+}
+
+html[theme='dark'] .test-case-success {
+    color: rgb(67, 132, 64) !important;
+}
+
+html[theme='dark'] .test-case-wrong {
+    color: rgb(248, 100, 86) !important;
+}
+
+html[theme='dark'] .form-control {
+    color: white !important;
+}
+
+html[theme='dark'] select {
+    background-color: #3f3f3f;
+    border: 1px solid #eee;
+}
+
+html[theme='dark'] .boj-modal {
+    background-color: #2f2f2f;
+    border-color: #eee;
+}
+
+html[theme='dark'] .boj-modal .modal-title > h1,
+html[theme='dark'] .boj-modal-close {
+    color: white;
+}
+
+html[theme='dark'] .boj-modal-close:hover {
+    color: #ff6262;
+}
+
+html[theme='dark'] .boj-modal .btn-default {
     background-color: #5f5f5f !important;
     border-color: #3f3f3f;
     color: white;
 }
 
-.algoplus-dark-theme .btn-default:hover,
-.algoplus-dark-theme .btn-default:active {
+html[theme='dark'] .boj-modal .btn-default:hover,
+html[theme='dark'] .boj-modal .btn-default:active {
     background-color: #8f8f8f !important;
 }
 
-.algoplus-dark-theme .boj-modal {
-    background-color: #2f2f2f;
-    border-color: #eee;
+html[theme='dark'] .boj-modal-body .btn-link {
+    background-color: transparent;
+    border-color: transparent !important;
+    color: rgb(137, 196, 232) !important;
 }
 
-.algoplus-dark-theme .boj-modal .modal-title > h1,
-.algoplus-dark-theme .boj-modal-close {
-    color: white;
-}
-
-.algoplus-dark-theme .boj-modal-close:hover {
-    color: #ff6262;
-}
-
-.algoplus-dark-theme .loading-dot {
-    background-color: white !important;
-}
-
-.algoplus-dark-theme .test-case-success {
-    color: rgb(67, 132, 64) !important;
-}
-
-.algoplus-dark-theme .test-case-wrong {
-    color: rgb(248, 100, 86) !important;
-}
-
-.algoplus-dark-theme .form-control {
+html[theme='dark'] pre,
+html[theme='dark'] .test-case-element > textarea[disabled] {
+    background-color: rgba(128, 128, 128, 0.05) !important;
+    border-color: #3c3c3c !important;
     color: white !important;
 }
 
-.algoplus-dark-theme input[type='text'] {
-    background-color: #2f2f2f;
-    border-color: #eee;
+html[theme='dark'] .test-case-element > textarea {
+    background-color: #3d3d3d !important;
+    border-color: #717171;
+    color: white !important;
 }
 
-.algoplus-dark-theme .alert-success {
-    background-color: #3f3f3f;
-    border-color: transparent;
-    color: white;
+html[theme='dark'] .resizer {
+    background-color: #939393;
 }
 
-.algoplus-dark-theme .table tbody tr:hover {
-    background-color: #4f4f4f;
+html[theme='dark'] .resizer:hover {
+    background-color: #005c6a;
 }
 
-.algoplus-dark-theme .table tbody tr.algoplus-code-select {
-    background-color: #1d3a00 !important;
+html[theme='dark'] .resizer:hover {
+    background-color: #005c6a;
 }
 
-.algoplus-dark-theme .btn-link {
-    color: #428bca !important;
-    background-color: transparent !important;
-    border-color: transparent !important;
+html[theme='dark'] .algoplus-status-table tbody tr:hover {
+    background-color: #3e3e3e;
 }
 
-/* 라이트 모드를 위한 스타일 설정 */
-.algoplus-light-theme #solve-view {
-    background-color: white;
-    color: #333 !important;
+html[theme='dark'] .algoplus-code-select {
+    background-color: #315000 !important;
 }
 
-.algoplus-light-theme #problem_title {
-    color: #585f69;
-}
-
-.algoplus-light-theme .headline {
-    border-bottom-color: #e4e9f0 !important;
-}
-
-.algoplus-light-theme .headline > h2 {
-    color: #585f69;
-    border-bottom-color: #0076c0 !important;
-}
-
-.algoplus-light-theme blockquote {
-    border-left-color: #eee !important;
-}
-
-.algoplus-light-theme .page-header,
-.algoplus-light-theme #problem-info th {
-    border-bottom-color: #eee !important;
-}
-
-.algoplus-light-theme #problem-info td {
-    border-top-color: #eee !important;
-}
-
-.algoplus-light-theme #problem_description *,
-.algoplus-light-theme #problem_input *,
-.algoplus-light-theme #problem_output *,
-.algoplus-light-theme #source *,
-.algoplus-light-theme .boj-modal .modal-title > h1,
-.algoplus-light-theme .boj-modal-close {
-    color: #555 !important;
-}
-
-.algoplus-light-theme pre {
-    border-color: #ccc !important;
-}
-
-.algoplus-light-theme ::-webkit-scrollbar-thumb:hover {
-    background-color: #555 !important;
-}
-
-.algoplus-light-theme ::-webkit-scrollbar-track {
-    background-color: transparent !important;
-}
-
-.algoplus-light-theme .panel.right a {
-    color: #0076c0 !important;
-}
-
-.algoplus-light-theme .panel.right * {
-    color: #555 !important;
-}
-
-.algoplus-light-theme .btn-default {
-    color: #333 !important;
-    background-color: #fff !important;
-    border-color: #ccc !important;
-}
-
-.algoplus-light-theme .btn-link {
-    color: #428bca !important;
-    background-color: transparent !important;
-    border-color: transparent !important;
+html[theme='dark'] .code-modal-container h4,
+html[theme='dark'] .code-modal-container p {
+    color: #585f69 !important;
 }


### PR DESCRIPTION
## ✅ DONE

- 문제풀기 화면 다크 테마 개선
    * 다른 백준 크롬 익스텐션 'BOJ Extended'와 디자인이 충돌하던 문제 개선(문제 풀기, 내 제출 페이지)
    * '내 제출' 페이지 다크 모드 제거

## 📝 TODO

- '내 제출' 페이지 오답노트 작성 팝업창 디자인 개선
- 오답노트 모달창 디자인 개선

## 🚀 RESULT

### BOJ Extended 다크 테마 적용
- BOJ Extended 다크 테마를 적용해도 디자인이 깨지지 않음
#### 문제풀이 페이지
![image](https://github.com/user-attachments/assets/b41c28e2-03dd-4f42-a4dd-f5152050a26b)

#### 테스트케이스 모달창
![image](https://github.com/user-attachments/assets/867ecd0e-66cd-4f16-81e8-ef18a1f40eaa)

#### '내 제출' 페이지
![image](https://github.com/user-attachments/assets/3231ae8e-18cf-48e9-8da2-1d00c92b50f5)
