### PR TITLE
일부 언어 경고 메시지 표시 이슈 해결 및 api 에러 메시지 개선

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,4 @@
-import { postprecessOutput } from './baekjoon/utils/compile';
+import { postprecessOutput, processErrorCode } from './baekjoon/utils/compile';
 import { CodeCompileRequest } from './common/types/compile';
 
 /**
@@ -21,9 +21,13 @@ async function compile(data: CodeCompileRequest) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
     })
-        .then((response) => response.json())
+        .then((response) => {
+            if (!response.ok) throw new Error(response.status.toString());
+            return response.json();
+        })
         .then((json) => json.output.trim())
-        .then((output) => postprecessOutput(data.language, output));
+        .then((output) => postprecessOutput(data.language, output))
+        .catch((e) => processErrorCode(e.message));
 }
 
 function handleMessage(request: any, sender: any, sendResponse: any) {

--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -43,6 +43,7 @@ import {
     saveDefaultLanguageId,
 } from '@/baekjoon/utils/storage/editor';
 import {
+    checkServerError,
     checkCompileError,
     preprocessSourceCode,
 } from '@/baekjoon/utils/compile';
@@ -176,16 +177,12 @@ const SolveView: React.FC<SolveViewProps> = ({
                         const newTestCases = [...currentTestCases];
                         newTestCases[index].result = output;
                         setTargetTestCases(newTestCases);
-                        if (checkCompileError(language, output)) {
+                        if (
+                            checkServerError(output) ||
+                            checkCompileError(language, output)
+                        ) {
                             setTestCaseState('error');
                             setErrorMessage(output);
-                            return;
-                        }
-                        if (output == 'error') {
-                            setTestCaseState('error');
-                            setErrorMessage(
-                                `컴파일 서버에서 오류가 발생했습니다.\n`
-                            );
                             return;
                         }
                     }

--- a/src/baekjoon/utils/compile.ts
+++ b/src/baekjoon/utils/compile.ts
@@ -47,6 +47,26 @@ const postprecessOutput = (
         const parts = output.split('Time Elapsed')[1].split('\n', 1);
         output = parts.length > 1 ? parts[1] : parts[0];
     }
+    if (language === 'java' && output.includes('Note: Main.java')) {
+        output = output.split('Note: Main.java')[0];
+    }
+    if (
+        language === 'csharp' &&
+        output.includes('Compilation succeeded') &&
+        output.includes('warning(s)')
+    ) {
+        const parts = output.split('warning(s)')[1].split('jdoodle.cs')[0];
+
+        const answer = parts
+            .split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+
+        output = answer.length > 0 ? answer[0] : '';
+    }
+    if (language === 'swift' && output.includes(': warning: ')) {
+        output = output.split('\njdoodle.swift')[0];
+    }
     if (output.includes('JDoodle - output Limit reached.')) {
         output = '출력 초과';
     }

--- a/src/baekjoon/utils/compile.ts
+++ b/src/baekjoon/utils/compile.ts
@@ -14,6 +14,16 @@ const CompileErrorFormatConvertMap: Record<CompilerLanguage, string> = {
     go: 'jdoodle.go',
 };
 
+const errorMessages: string[] = [
+    `Algo Plus - 서비스 이용 한도 초과 안내\n
+    현재 이용량 증가로 인해 일일 코드 실행 호출 한도가 초과되었습니다.
+    한도는 매일 오전 9시에 자동으로 초기화됩니다.\n
+    더 나은 서비스와 안정적인 환경을 제공하기 위해 최선을 다하겠습니다.
+    너른 양해 부탁드립니다.`,
+    '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    '올바르지 않은 요청입니다. 같은 문제가 계속 발생한다면 관리자에게 문의해주세요.\n\n문의: algoplus.official@gmail.com',
+];
+
 /* JDoodle compile API 동작을 위한 별도의 처리가 필요한 경우 코드를 전처리 */
 const preprocessSourceCode = (
     language: CompilerLanguage,
@@ -53,4 +63,23 @@ const checkCompileError = (lang: CompilerLanguage, output: string): boolean => {
     return output.includes(CompileErrorFormatConvertMap[lang]);
 };
 
-export { preprocessSourceCode, postprecessOutput, checkCompileError };
+const checkServerError = (output: string): boolean => {
+    return errorMessages.includes(output);
+};
+
+const processErrorCode = (status: number): string => {
+    if (status == 429) {
+        return errorMessages[0];
+    } else if (status < 500) {
+        return errorMessages[2];
+    }
+    return errorMessages[1];
+};
+
+export {
+    preprocessSourceCode,
+    postprecessOutput,
+    checkCompileError,
+    checkServerError,
+    processErrorCode,
+};

--- a/src/baekjoon/utils/compile.ts
+++ b/src/baekjoon/utils/compile.ts
@@ -90,7 +90,7 @@ const checkServerError = (output: string): boolean => {
 const processErrorCode = (status: number): string => {
     if (status == 429) {
         return errorMessages[0];
-    } else if (status < 500) {
+    } else if (status < 410) {
         return errorMessages[2];
     }
     return errorMessages[1];

--- a/src/baekjoon/utils/language.ts
+++ b/src/baekjoon/utils/language.ts
@@ -24,7 +24,7 @@ const submitApiVersionConvertMap: Record<string, string> = {
     '84': '1',
     '95': '1',
     '86': '3',
-    '3': '0',
+    '3': '3',
     '93': '3',
     '28': '5',
     '73': '5',


### PR DESCRIPTION
## ✅ DONE

#### 1. 에러 코드에 따른 에러 메시지 표시 방식 변경
- 400/401
```
올바르지 않은 요청입니다. 같은 문제가 계속 발생한다면 관리자에게 문의해주세요.

문의: algoplus.official@gmail.com
```
- 429: Daily Limit Reached
```
Algo Plus - 서비스 이용 한도 초과 안내

현재 이용량 증가로 인해 일일 코드 실행 호출 한도가 초과되었습니다.
한도는 매일 오전 9시에 자동으로 초기화됩니다.

더 나은 서비스와 안정적인 환경을 제공하기 위해 최선을 다하겠습니다.
너른 양해 부탁드립니다.
```
- 500 or 410: Server Error
```
서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.
```

#### 2. C#, Java, Swift 에 대한 경고 메시지 제거 작업

#### 3. Java 8 한글 주석 인코딩 이슈로 인한 api 버전 업
- Java 9, 10도 모두 같은 문제가 있어 11로 버전 업

## 📝 TODO

- 추가 컴파일 이슈 발견 및 해결

## 🚀 RESULT
![image](https://github.com/user-attachments/assets/8ba85009-10c5-4df0-b5f3-6f1cc19b248b)
