### PR TITLE
BOJ Extended 어두운 테마일 때, 결과창 오류 메시지 색상이 적용되지 않는 문제 해결

### DIFF
--- a/src/baekjoon/presentations/TestCasePanel/TestCasePanel.tsx
+++ b/src/baekjoon/presentations/TestCasePanel/TestCasePanel.tsx
@@ -25,7 +25,10 @@ const TestCasePanel: React.FC<TestCasePanelProps> = ({
                     실행 결과가 여기에 표시됩니다.
                 </p>
             ) : state === 'error' && errorMessage ? (
-                <p style={{ padding: '10px', color: 'red' }}>
+                <p
+                    className='test-case-panel-error-message'
+                    style={{ padding: '10px', color: 'red' }}
+                >
                     <span
                         dangerouslySetInnerHTML={{
                             __html: replaceNewLineToBrTag(errorMessage),

--- a/src/baekjoon/scripts/submit.css
+++ b/src/baekjoon/scripts/submit.css
@@ -41,6 +41,11 @@ html[theme='dark'] .test-case-wrong {
     color: rgb(248, 100, 86) !important;
 }
 
+html[theme='dark'] .test-case-panel-error-message,
+html[theme='dark'] .test-case-panel-error-message * {
+    color: rgb(248, 100, 86) !important;
+}
+
 html[theme='dark'] .form-control {
     color: white !important;
 }


### PR DESCRIPTION
## ✅ DONE

- BOJ Extended 어두운 테마일 때, 결과창 오류 메시지 색상이 적용되지 않는 문제 해결

## 🚀 RESULT
- BOJ Extended 어두운 테마일 경우
![image](https://github.com/user-attachments/assets/52bbe3a8-449e-412b-9e2f-e2acdb9379ca)