### PR TITLE
오답노트 로컬 저장 시 파일 이름이 유니크하도록 수정

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 import { postprecessOutput, processErrorCode } from '@/common/utils/compile';
 import { CodeCompileRequest } from '@/common/types/compile';
-import { trimLineByLine } from '@/common/utils/string';
+import { formatDate, trimLineByLine } from '@/common/utils/string';
 
 /**
  * solvedac 문제 데이터를 파싱해오는 함수.
@@ -90,18 +90,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         reader.onloadend = () => {
             const dataUrl = reader.result;
 
+            const filename = `${request.platform}_${
+                request.problemId
+            }_${formatDate(new Date())}.md`;
+
             if (typeof dataUrl === 'string') {
                 chrome.downloads.download(
                     {
                         url: dataUrl,
-                        filename: `AlgoPlus${today.getFullYear()}${(
-                            today.getMonth() + 1
-                        )
-                            .toString()
-                            .padStart(2, '0')}${today
-                            .getDate()
-                            .toString()
-                            .padStart(2, '0')}.md`,
+                        filename: filename,
                         saveAs: true,
                     },
                     (downloadId) => {

--- a/src/baekjoon/containers/ReviewNotePopUp/ReviewNotePopUp.tsx
+++ b/src/baekjoon/containers/ReviewNotePopUp/ReviewNotePopUp.tsx
@@ -196,6 +196,7 @@ const ReviewNotePopUp: React.FC<ReviewNotePopUpProps> = ({ problemId }) => {
                 }
             />
             <ReviewNoteModal
+                problemId={problemId}
                 codeDescriptions={codeInfos.map((codeInfo, index) => (
                     <CodeInfoNoteHeader
                         key={codeInfo.submissionId}

--- a/src/common/containers/ReviewNoteModal/ReviewNoteModal.tsx
+++ b/src/common/containers/ReviewNoteModal/ReviewNoteModal.tsx
@@ -22,6 +22,7 @@ import { OverlayNotification } from '@/common/components/OverlayNotification';
 import { ReviewWriteBlockWrapper } from '@/common/containers/ReviewWriteBlockWrapper';
 
 type ReviewNoteModalProps = {
+    problemId: string;
     modalOpen: boolean;
     onClose: () => void;
     codeDescriptions: (string | JSX.Element)[];
@@ -116,6 +117,8 @@ const ReviewNoteModal: React.FC<ReviewNoteModalProps> = (
         chrome.runtime.sendMessage({
             action: 'saveRepository',
             content: getMarkdownContent(),
+            platform: 'BOJ',
+            problemId: props.problemId,
         });
     };
 

--- a/src/common/utils/string.ts
+++ b/src/common/utils/string.ts
@@ -8,3 +8,16 @@ export const trimLineByLine = (text: string): string => {
         .map((line) => line.trim())
         .join('\n');
 };
+
+export const formatDate = (date: Date) => {
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    return (
+        date.getFullYear().toString() +
+        pad(date.getMonth() + 1) +
+        pad(date.getDate()) +
+        '_' +
+        pad(date.getHours()) +
+        pad(date.getMinutes()) +
+        pad(date.getSeconds())
+    );
+};


### PR DESCRIPTION
## ✅ DONE

- 오답노트 로컬 저장 시 파일 이름이 유니크하도록 수정

## 📝 TODO

- 깃허브 파일 저장 네이밍도 논의 필요

## 🚀 RESULT

- 파일 이름 양식 `플랫폼_문제번호_날짜_시간` 양식으로 저장되도록 개선
![image](https://github.com/user-attachments/assets/cdea4a36-698f-4b5f-b92d-e0399b4e56ef)
