### PR TITLE
코드 실행 버튼 쿨다운 효과 추가

### DIFF
--- a/src/baekjoon/containers/SolveView/SolveView.tsx
+++ b/src/baekjoon/containers/SolveView/SolveView.tsx
@@ -92,6 +92,9 @@ const SolveView: React.FC<SolveViewProps> = ({
     const codeRef = useRef<string>(code);
     const languageIdRef = useRef<string>(languageId);
 
+    const complieWaitMs = 3_500;
+    const [isCompile, setIsCompile] = useState<boolean>(false);
+
     const codeInitialize = () => {
         setCode(getDefaultCode(editorLanguage));
     };
@@ -145,12 +148,18 @@ const SolveView: React.FC<SolveViewProps> = ({
     };
 
     const codeRun = async () => {
+        if (isCompile) return;
         if (!code) {
             alert('실행할 코드가 없습니다.');
             return;
         }
 
         saveEditorCode(problemId, languageId, code);
+
+        setIsCompile(true);
+        setTimeout(() => {
+            setIsCompile(false);
+        }, complieWaitMs);
         setTestCaseState('running');
 
         const language = convertLanguageIdForSubmitApi(languageId);
@@ -441,8 +450,9 @@ const SolveView: React.FC<SolveViewProps> = ({
                     runHandle={codeRun}
                     submitHandle={codeSubmit}
                     openReferenceUrl={openReferenceUrl}
-                    isRunning={testCaseState == 'running'}
+                    isRunning={isCompile}
                     isSubmitting={isSubmitting}
+                    complieWaitMs={complieWaitMs}
                 />
             </div>
 

--- a/src/baekjoon/presentations/EditorButtonBox/EditorButtonBox.css
+++ b/src/baekjoon/presentations/EditorButtonBox/EditorButtonBox.css
@@ -1,4 +1,31 @@
 .loading {
-    opacity: 0.5;
+    position: relative;
+    overflow: hidden;
+    opacity: 1; 
     color: rgb(204, 204, 204);
+}
+
+.loading::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgb(204, 204, 204, 0.5);
+    transform: scaleY(0);
+    transform-origin: bottom;
+    animation: fill-up var(--loading-ms, 10s) linear forwards;
+    z-index: 1;
+}
+
+.loading span {
+    position: relative;
+    z-index: 0;
+}
+
+@keyframes fill-up {
+    from {
+        transform: scaleY(0);
+    }
+    to {
+        transform: scaleY(1);
+    }
 }

--- a/src/baekjoon/presentations/EditorButtonBox/EditorButtonBox.tsx
+++ b/src/baekjoon/presentations/EditorButtonBox/EditorButtonBox.tsx
@@ -8,7 +8,8 @@ const EditorButtonBox: React.FC<EditorButtonBoxProps> = ({
     runHandle,
     submitHandle,
     isRunning,
-    isSubmitting
+    isSubmitting,
+    complieWaitMs
 }) => {
     return (
         <div style={{ display: 'flex', gap: '10px', justifyContent: 'right' }}>
@@ -25,8 +26,9 @@ const EditorButtonBox: React.FC<EditorButtonBoxProps> = ({
                 className={`btn btn-default ${isRunning ? 'loading' : ''}`}
                 onClick={runHandle}
                 disabled={isRunning}
+                style={{ ['--loading-ms']: `${complieWaitMs}ms` } as React.CSSProperties}
             >
-                {isRunning ? '실행 중...' : '실행'}
+                실행
             </button>
             <button 
                 className='btn btn-primary' 
@@ -47,6 +49,7 @@ interface EditorButtonBoxProps {
     submitHandle: () => void;
     isRunning: boolean;
     isSubmitting: boolean;
+    complieWaitMs: number;
 }
 
 export default EditorButtonBox;


### PR DESCRIPTION
## ✅ DONE
- 코드 실행 버튼에 3.5초 쿨다운 효과를 추가 했습니다.
- 비고
   - 현재는 3.5초로 고정되어 있음 (`complieWaitMs` 변경 시 조정 가능)
   - 3초는 짧고, 5초 이상은 너무 길다고 판단하였습니다.
  
## 🚀 RESULT
![chrome-capture-2025-9-7](https://github.com/user-attachments/assets/95485bd2-bf22-4edf-a6ef-be2b507c4b4b)
