### PR TITLE
테스트 케이스 채점 로직에서 공백으로 인해 채점 결과가 틀리게 나오는 버그 해결

### DIFF
--- a/src/baekjoon/components/TestCaseResultElement/TestCaseResultElement.tsx
+++ b/src/baekjoon/components/TestCaseResultElement/TestCaseResultElement.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './TestCaseResultElement.css';
-import { replaceNewLineToBrTag } from '@/common/utils/string';
+import { replaceSpaceAndNewlineToHtml } from '@/common/utils/string';
 
 const TestCaseResultElement: React.FC<TestCaseResultElementProps> = ({
     no,
@@ -16,7 +16,7 @@ const TestCaseResultElement: React.FC<TestCaseResultElementProps> = ({
                 <span>입력값</span>
                 <span
                     dangerouslySetInnerHTML={{
-                        __html: replaceNewLineToBrTag(input),
+                        __html: replaceSpaceAndNewlineToHtml(input),
                     }}
                 ></span>
             </p>
@@ -24,7 +24,7 @@ const TestCaseResultElement: React.FC<TestCaseResultElementProps> = ({
                 <span>기댓값</span>
                 <span
                     dangerouslySetInnerHTML={{
-                        __html: replaceNewLineToBrTag(expectedValue),
+                        __html: replaceSpaceAndNewlineToHtml(expectedValue),
                     }}
                 ></span>
             </p>
@@ -66,7 +66,7 @@ const TestCaseResultElement: React.FC<TestCaseResultElementProps> = ({
                     ) : (
                         <span
                             dangerouslySetInnerHTML={{
-                                __html: replaceNewLineToBrTag(output),
+                                __html: replaceSpaceAndNewlineToHtml(output),
                             }}
                         ></span>
                     )}
@@ -76,7 +76,7 @@ const TestCaseResultElement: React.FC<TestCaseResultElementProps> = ({
                     <span>출력</span>
                     <span
                         dangerouslySetInnerHTML={{
-                            __html: replaceNewLineToBrTag(output),
+                            __html: replaceSpaceAndNewlineToHtml(output),
                         }}
                     ></span>
                 </p>

--- a/src/baekjoon/presentations/TestCasePanel/TestCasePanel.tsx
+++ b/src/baekjoon/presentations/TestCasePanel/TestCasePanel.tsx
@@ -1,6 +1,6 @@
 import TestCaseResultElement from '@/baekjoon/components/TestCaseResultElement/TestCaseResultElement';
 import { TestCase } from '@/baekjoon/types/problem';
-import { replaceNewLineToBrTag } from '@/common/utils/string';
+import { replaceSpaceAndNewlineToHtml } from '@/common/utils/string';
 import React from 'react';
 
 interface TestCasePanelProps {
@@ -31,7 +31,7 @@ const TestCasePanel: React.FC<TestCasePanelProps> = ({
                 >
                     <span
                         dangerouslySetInnerHTML={{
-                            __html: replaceNewLineToBrTag(errorMessage),
+                            __html: replaceSpaceAndNewlineToHtml(errorMessage),
                         }}
                     ></span>
                 </p>

--- a/src/baekjoon/utils/parsing.tsx
+++ b/src/baekjoon/utils/parsing.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TestCase } from '@/baekjoon/types/problem';
 import uuid from 'react-uuid';
+import { trimLineByLine } from '@/common/utils/string';
 
 export const getProblemId = (): string | null => {
     const problemIdElement = document.querySelector(
@@ -87,7 +88,7 @@ export const parsingTestCases = (html: string): TestCase[] => {
         testCases.push({
             uuid: uuid(),
             input: (inputs[i].textContent as string).trim(),
-            output: (outputs[i].textContent as string).trim(),
+            output: trimLineByLine(outputs[i].textContent as string),
             isMultiAnswer: isMultiAnswer != null,
         });
     }

--- a/src/common/utils/string.ts
+++ b/src/common/utils/string.ts
@@ -1,4 +1,5 @@
-export const replaceNewLineToBrTag = (string: string): string => {
+export const replaceSpaceAndNewlineToHtml = (string: string): string => {
+    string = string.replace(/ /g, '&nbsp;');
     return string.replace(/(\r\n|\r|\n)/g, '<br>');
 };
 
@@ -6,7 +7,8 @@ export const trimLineByLine = (text: string): string => {
     return text
         .split('\n')
         .map((line) => line.trim())
-        .join('\n');
+        .join('\n')
+        .trim();
 };
 
 export const formatDate = (date: Date) => {


### PR DESCRIPTION
## ✅ DONE

- output과 actual output을 비교할 때 양 끝의 공백 문자 제거(trim)
- 테스트 케이스 실행 결과 출력 시 공백 문자가 여러개여도 1개로 보이는 버그 수정(`&nbsp;`로 처리)